### PR TITLE
Feat: 사용자 취향 필터 기반 Mock API 구현 #21

### DIFF
--- a/app/api/api.py
+++ b/app/api/api.py
@@ -3,8 +3,10 @@ from fastapi import APIRouter
 from app.api.v1.auth.kakao import router as auth_router
 from app.api.v1.endpoints.user import router as user_router
 from app.api.v1.endpoints.routes import router as routes_router
+from app.api.v1.endpoints.recommendations import router as recommendations_router
 
 api_router = APIRouter()
 api_router.include_router(auth_router, tags=["auth"])
 api_router.include_router(user_router, tags=["user"])
 api_router.include_router(routes_router, tags=["routes"])
+api_router.include_router(recommendations_router, tags=["ai-recommendations"])

--- a/app/api/v1/endpoints/recommendations.py
+++ b/app/api/v1/endpoints/recommendations.py
@@ -1,0 +1,48 @@
+from fastapi import APIRouter, Depends, status
+from app.schemas.recommendations import AIRecommendationRequest, AIRecommendationResponse
+from app.core.jwt import get_current_user  
+
+router = APIRouter()
+
+@router.post(
+    "/ai-recommendations",
+    response_model=AIRecommendationResponse,
+    status_code=status.HTTP_200_OK,
+    summary="AI 맞춤 동선 추천 (Mock API)",
+)
+async def get_ai_recommendation(
+    request_data: AIRecommendationRequest,
+    # current_user_id: str = Depends(get_current_user)
+):
+    current_user_id = "임시_테스트_유저_ID"
+    print(f"🔒 인증에 성공한 유저 UUID: {current_user_id}")
+    duration_text = request_data.duration.value
+    transport_text = request_data.transportation.value
+    purpose_text = request_data.travel_purpose.value
+    companion_text = request_data.companion.value
+    atmosphere_text = request_data.atmosphere.value if request_data.atmosphere else "기본적인"
+    activity_text = request_data.activity_style.value if request_data.activity_style else "유연한"
+    region_text = request_data.region if request_data.region else "선택 안 함"
+    
+    print(f"🤖 [AI 프롬프트 준비 완료] 지역: {region_text} | 동반자: {companion_text} | 목적: {purpose_text}")
+
+    mock_response = {
+        "title": f"[{region_text}] {companion_text}과 함께 떠나는 {purpose_text} 추천 코스",
+        "estimated_time": f"총 예상 소요 시간: {duration_text}",
+        "places": [
+            {
+                "visit_order": 1,
+                "name": f"{region_text} 감성 스팟 A",
+                "address": f"{region_text} 중심가 123",
+                "description": f"{companion_text}과 함께 {atmosphere_text} 분위기를 만끽하며, {transport_text}(으)로 부담 없이 방문하기 좋은 첫 번째 장소입니다."
+            },
+            {
+                "visit_order": 2,
+                "name": f"{region_text} 로컬 맛집 B",
+                "address": f"{region_text} 맛집 거리 456",
+                "description": f"{purpose_text}에 딱 어울리는 스팟으로, {activity_text} 여행을 선호하는 분들에게 강력히 추천하는 코스입니다."
+            }
+        ]
+    }
+    
+    return mock_response

--- a/app/schemas/recommendations.py
+++ b/app/schemas/recommendations.py
@@ -1,0 +1,66 @@
+from enum import Enum
+from pydantic import BaseModel, Field
+
+# 선택지 정의
+class DurationType(str, Enum):
+    SHORT = "1~2시간"
+    HALF_DAY = "반나절"
+    ONE_DAY = "하루"
+    TWO_DAYS = "1박2일"
+    THREE_DAYS = "2박3일"
+    ETC = "기타"
+
+class TransportType(str, Enum):
+    PUBLIC = "대중교통"
+    CAR = "자차"
+    WALK = "도보"
+    BIKE = "자전거"
+
+class PurposeType(str, Enum):
+    HEALING = "힐링"
+    DATE = "데이트"
+    TRENDY = "인스타감성"
+    NATURE = "자연/풍경"
+    LOCAL = "현지경험"
+    HISTORIC = "역사/문화"
+
+class CompanionType(str, Enum):
+    ALONE = "혼자"
+    FRIENDS = "친구"
+    COUPLE = "연인"
+    FAMILY = "가족"
+    PARENTS = "부모님"
+    WITH_KIDS = "아이와 함께"
+    WITH_PET = "반려동물과 함께"
+    GROUP = "동아리/단체"
+
+class AtmosphereType(str, Enum):
+    QUIET = "조용한"
+    EMOTIONAL = "감성적인"
+    LIVELY = "활기찬"
+    LOCAL_VIBE = "로컬 느낌"
+    HIP = "힙한 분위기"
+
+class ActivityStyle(str, Enum):
+    DYNAMIC = "액티비티/활동적"
+    STATIC = "정적/잔잔함"
+
+class AIRecommendationRequest(BaseModel):
+    duration: DurationType = Field(..., description="여행 소요 시간")
+    transportation: TransportType = Field(..., description="이동 수단")
+    travel_purpose: PurposeType = Field(..., description="여행 목적")
+    companion: CompanionType = Field(..., description="여행 동반자")
+    atmosphere: AtmosphereType | None = Field(None, description="선호 분위기")
+    activity_style: ActivityStyle | None = Field(None, description="활동 스타일")
+    region: str | None = Field(None, description="여행 목적지")
+
+class RecommendedPlace(BaseModel):
+    visit_order: int
+    name: str
+    address: str
+    description: str
+
+class AIRecommendationResponse(BaseModel):
+    title: str
+    estimated_time: str
+    places: list[RecommendedPlace]


### PR DESCRIPTION
##  #21
AI 맞춤 동선 추천 API 구현 (`POST /api/v1/ai-recommendations`)

JWT 관련 참고사항
원래 토큰 검증을 해야 하는데, 로컬에서 매번 토큰을 새로 발급받아 테스트하기가 번거로워서 일단 주석 처리해 두었습니다!
대신 `current_user_id = "임시_테스트_유저_ID"`를 임시로 넣어두어 토큰 없이도 `200 OK` 응답을 확인하실 수 있습니다.
나중에 프론트엔드랑 최종 합쳐서 테스트할 때 주석만 풀면 됩니다!

로직
1. 프론트가 보낸 7가지 취향 필터를 백엔드가 받음
2. 사용자가 보낸 선택지에서 실제 텍스트 내용을 뽑아냄
3. 나중에 AI 프롬프트 짤 때 바로 가져다 쓸 수 있도록, 텍스트 변수들을 콘솔 창(`print`)에 미리 찍어보게끔 준비해 두었습니다.
4. 최종 데이터를 정해진 규격에 맞춰 프론트엔드에 `200 OK`로 응답
