### PR TITLE
feat: 추천 이유 생성에 OpenAI LLM 연동 및 fallback 처리 추가

### DIFF
--- a/app/services/recommendation_reasoning.py
+++ b/app/services/recommendation_reasoning.py
@@ -1,5 +1,10 @@
 from dataclasses import dataclass
+import json
+from typing import Any
 
+import httpx
+
+from app.core.config import settings
 from app.schemas.recommendations import (
     AIReasonDetail,
     RecommendationSummary,
@@ -23,7 +28,7 @@ def build_recommendation_reason(
     summary: RecommendationSummary,
     places: list[RouteRecommendationPlace],
 ) -> RecommendationReasonResult:
-    return build_rule_based_recommendation_reason(
+    fallback_result = build_rule_based_recommendation_reason(
         region=region,
         theme_label=theme_label,
         transport_label=transport_label,
@@ -31,6 +36,21 @@ def build_recommendation_reason(
         summary=summary,
         places=places,
     )
+    if not _should_call_openai():
+        return fallback_result
+
+    try:
+        return _build_openai_recommendation_reason(
+            region=region,
+            theme_label=theme_label,
+            transport_label=transport_label,
+            companion_label=companion_label,
+            summary=summary,
+            places=places,
+            fallback_detail=fallback_result.detail,
+        )
+    except Exception:
+        return fallback_result
 
 
 def build_rule_based_recommendation_reason(
@@ -139,4 +159,160 @@ def _join_names(places: list[RouteRecommendationPlace]) -> str:
     if len(names) == 1:
         return names[0]
     return ", ".join(names[:-1]) + f", {names[-1]}"
+
+
+def _should_call_openai() -> bool:
+    return bool(
+        settings.openai_api_key
+        and settings.llm_provider.strip().lower() == "openai"
+    )
+
+
+def _build_openai_recommendation_reason(
+    *,
+    region: RegionItem,
+    theme_label: str,
+    transport_label: str,
+    companion_label: str,
+    summary: RecommendationSummary,
+    places: list[RouteRecommendationPlace],
+    fallback_detail: AIReasonDetail,
+) -> RecommendationReasonResult:
+    response = httpx.post(
+        "https://api.openai.com/v1/chat/completions",
+        headers={
+            "Authorization": f"Bearer {settings.openai_api_key}",
+            "Content-Type": "application/json",
+        },
+        json={
+            "model": settings.openai_model,
+            "messages": [
+                {
+                    "role": "system",
+                    "content": (
+                        "You write concise Korean travel route recommendation reasons for Tripick. "
+                        "Use only the supplied selected places. Do not add new places or reorder them. "
+                        "Return strict JSON only."
+                    ),
+                },
+                {
+                    "role": "user",
+                    "content": _build_openai_prompt(
+                        region=region,
+                        theme_label=theme_label,
+                        transport_label=transport_label,
+                        companion_label=companion_label,
+                        summary=summary,
+                        places=places,
+                    ),
+                },
+            ],
+            "temperature": 0.4,
+            "response_format": {"type": "json_object"},
+        },
+        timeout=settings.llm_timeout_seconds,
+    )
+    response.raise_for_status()
+    payload = response.json()
+    content = payload["choices"][0]["message"]["content"]
+    data = _parse_openai_json_content(content)
+
+    reason_detail = AIReasonDetail(
+        overview=_get_non_empty_string(data, "overview", fallback_detail.overview),
+        route_design=_get_non_empty_string(
+            data,
+            "route_design",
+            fallback_detail.route_design,
+        ),
+        local_contribution=_get_non_empty_string(
+            data,
+            "local_contribution",
+            fallback_detail.local_contribution,
+        ),
+        traveler_fit=_get_non_empty_string(
+            data,
+            "traveler_fit",
+            fallback_detail.traveler_fit,
+        ),
+        closing_tip=_get_non_empty_string(data, "closing_tip", fallback_detail.closing_tip),
+        highlights=_get_highlights(data, fallback_detail.highlights),
+        generation_source="llm_openai",
+    )
+    return RecommendationReasonResult(
+        text=build_ai_reason_text(reason_detail),
+        detail=reason_detail,
+    )
+
+
+def _build_openai_prompt(
+    *,
+    region: RegionItem,
+    theme_label: str,
+    transport_label: str,
+    companion_label: str,
+    summary: RecommendationSummary,
+    places: list[RouteRecommendationPlace],
+) -> str:
+    place_lines = [
+        (
+            f"{place.order}. {place.name} | category={place.category} | "
+            f"stay={place.stay_minutes}min | local_consumption={place.is_local_consumption} | "
+            f"score={place.recommendation_score} | reason={place.reason} | "
+            f"contribution={place.contribution_reason}"
+        )
+        for place in places
+    ]
+    return (
+        "다음은 이미 점수 기반 추천 로직으로 선별된 장소 목록입니다. "
+        "장소를 새로 고르거나 순서를 바꾸지 말고, 추천 이유 문장만 생성하세요.\n\n"
+        f"지역: {region.sido} {region.sigungu}\n"
+        f"테마: {theme_label}\n"
+        f"이동수단: {transport_label}\n"
+        f"동행: {companion_label}\n"
+        f"예상 시간: {summary.duration_text}\n"
+        f"예상 비용: {summary.cost_range_text}\n"
+        f"지역 기여도: {summary.contribution_label}\n"
+        f"로컬 소비: {summary.local_consumption_text}\n\n"
+        "선별 장소:\n"
+        + "\n".join(place_lines)
+        + "\n\n"
+        "아래 JSON 형식으로만 답하세요.\n"
+        "{\n"
+        '  "overview": "한두 문장",\n'
+        '  "route_design": "동선 구성 이유",\n'
+        '  "local_contribution": "지역 소비/기여 설명",\n'
+        '  "traveler_fit": "사용자 조건 적합성 설명",\n'
+        '  "closing_tip": "마무리 팁",\n'
+        '  "highlights": ["핵심 포인트 1", "핵심 포인트 2", "핵심 포인트 3"]\n'
+        "}"
+    )
+
+
+def _parse_openai_json_content(content: str) -> dict[str, Any]:
+    parsed = json.loads(content)
+    if not isinstance(parsed, dict):
+        raise ValueError("OpenAI recommendation reason response must be a JSON object.")
+    return parsed
+
+
+def _get_non_empty_string(
+    data: dict[str, Any],
+    key: str,
+    fallback: str,
+) -> str:
+    value = data.get(key)
+    if isinstance(value, str) and value.strip():
+        return value.strip()
+    return fallback
+
+
+def _get_highlights(
+    data: dict[str, Any],
+    fallback: list[str],
+) -> list[str]:
+    value = data.get("highlights")
+    if not isinstance(value, list):
+        return fallback
+    highlights = [str(item).strip() for item in value if str(item).strip()]
+    return highlights[:3] or fallback
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,9 @@
+import pytest
+
+from app.core.config import settings
+
+
+@pytest.fixture(autouse=True)
+def disable_external_llm_calls(monkeypatch):
+    monkeypatch.setattr(settings, "openai_api_key", None)
+    monkeypatch.setattr(settings, "gemini_api_key", None)

--- a/tests/test_recommendation_reasoning.py
+++ b/tests/test_recommendation_reasoning.py
@@ -1,8 +1,12 @@
+import json as json_module
+
+from app.core.config import settings
 from app.schemas.recommendations import RecommendationRequest
+from app.services import recommendation_reasoning
 from app.services.recommendations import create_recommendation
 
 
-def test_ai_reason_detail_mentions_route_and_local_contribution() -> None:
+def test_ai_reason_detail_falls_back_to_rule_based_when_openai_key_is_missing() -> None:
     response = create_recommendation(
         RecommendationRequest(
             region_id="region-danyang",
@@ -12,15 +16,81 @@ def test_ai_reason_detail_mentions_route_and_local_contribution() -> None:
             companion="friends",
         )
     )
-    data = response.model_dump()
 
-    assert "단양군" in data["ai_reason"]
-    assert "도담삼봉" in data["ai_reason"]
-    assert "단양구경시장" in data["ai_reason_detail"]["local_contribution"]
-    assert data["ai_reason_detail"]["generation_source"] == "rule_based_ai_ready"
-    assert data["ai_reason_detail"]["highlights"] == [
-        "힐링 테마 적합",
-        "지역 기여도 86점",
-        "로컬 소비 장소 2곳 포함",
-    ]
+    assert response.ai_reason
+    assert response.ai_reason_detail.generation_source == "rule_based_ai_ready"
+    assert response.ai_reason_detail.highlights
 
+
+def test_ai_reason_detail_can_be_generated_by_openai(monkeypatch) -> None:
+    class FakeOpenAIResponse:
+        def raise_for_status(self):
+            return None
+
+        def json(self):
+            return {
+                "choices": [
+                    {
+                        "message": {
+                            "content": json_module.dumps(
+                                {
+                                    "overview": "LLM overview",
+                                    "route_design": "LLM route design",
+                                    "local_contribution": "LLM local contribution",
+                                    "traveler_fit": "LLM traveler fit",
+                                    "closing_tip": "LLM closing tip",
+                                    "highlights": ["LLM highlight"],
+                                }
+                            )
+                        }
+                    }
+                ]
+            }
+
+    def fake_post(url, *, headers, json, timeout):
+        assert url == "https://api.openai.com/v1/chat/completions"
+        assert headers["Authorization"] == "Bearer test-openai-key"
+        assert "test-openai-key" not in str(json)
+        assert timeout == settings.llm_timeout_seconds
+        return FakeOpenAIResponse()
+
+    monkeypatch.setattr(settings, "openai_api_key", "test-openai-key")
+    monkeypatch.setattr(settings, "llm_provider", "openai")
+    monkeypatch.setattr(recommendation_reasoning.httpx, "post", fake_post)
+
+    response = create_recommendation(
+        RecommendationRequest(
+            region_id="region-danyang",
+            theme="healing",
+            travel_time="half_day",
+            transport="walk",
+            companion="friends",
+        )
+    )
+
+    assert response.ai_reason_detail.generation_source == "llm_openai"
+    assert response.ai_reason_detail.overview == "LLM overview"
+    assert response.ai_reason_detail.highlights == ["LLM highlight"]
+    assert "LLM overview" in response.ai_reason
+
+
+def test_ai_reason_detail_falls_back_when_openai_call_fails(monkeypatch) -> None:
+    def fake_post(*args, **kwargs):
+        raise RuntimeError("network failure")
+
+    monkeypatch.setattr(settings, "openai_api_key", "test-openai-key")
+    monkeypatch.setattr(settings, "llm_provider", "openai")
+    monkeypatch.setattr(recommendation_reasoning.httpx, "post", fake_post)
+
+    response = create_recommendation(
+        RecommendationRequest(
+            region_id="region-danyang",
+            theme="healing",
+            travel_time="half_day",
+            transport="walk",
+            companion="friends",
+        )
+    )
+
+    assert response.ai_reason
+    assert response.ai_reason_detail.generation_source == "rule_based_ai_ready"


### PR DESCRIPTION
## 작업 내용
- 추천 이유 생성 단계에 OpenAI LLM 호출 로직 추가
- 장소 추천/점수 계산/코스 선별 로직은 변경하지 않음
- OpenAI 호출 성공 시 generation_source="llm_openai" 반환
- API key 없음, 호출 실패, 파싱 실패, 네트워크 실패 시 기존 rule_based_ai_ready 방식으로 fallback
- 테스트 환경에서는 실제 외부 LLM 호출이 발생하지 않도록 설정

## 테스트
- cmd /c python -m pytest -q
- 46 passed, 3 warnings

## 비고
- warnings는 기존 Pydantic Field(example=...) deprecation warning으로 이번 작업과 무관